### PR TITLE
Added /status for plugins to see the status of url checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,6 @@ async function getFailedUrls(settings){
 
 const getDataForAllUrls = async(options) => {
     await influx.markStatusLogs(options.influx, "START", Date.now());
-   
     var items_to_process = options.items;    
     const all_urls = items_to_process.map(url => url.url_settings.url);
     

--- a/src/influx/index.js
+++ b/src/influx/index.js
@@ -53,16 +53,18 @@ const markSuccess = async (influxdb, url) => {
     }
 }
 
-//state = {0, 1, 2}
-// 0 -> in process
-// 1 -> finished successfully
-// 2 -> failed
+/*
+   state = {0, 1, 2}
+   0 -> in process
+   1 -> finished successfully
+   2 -> failed
+*/
 const markStatus = async (influxdb, url, state, timestamp, retry) => {
     try {
         const measurement = [ {
             measurement: "status",
             tags: { url: url, state: state },
-            fields: { date: timestamp, retry: retry }           
+            fields: { retry: retry }           
         }];
 
         const result = await influxdb.writePoints(measurement);
@@ -74,7 +76,7 @@ const markStatus = async (influxdb, url, state, timestamp, retry) => {
     }
 }
 
-//steps = {START, WAITING, RETRY 1, RETRY 2, ..., FINISHED}
+// steps = {START, WAITING, RETRY 1, RETRY 2, ..., FINISHED}
 const markStatusLogs = async (influxdb, step, timestamp) => {
     try {
         const measurement = [ {

--- a/src/influx/index.js
+++ b/src/influx/index.js
@@ -53,9 +53,50 @@ const markSuccess = async (influxdb, url) => {
     }
 }
 
+//state = {0, 1, 2}
+// 0 -> in process
+// 1 -> finished successfully
+// 2 -> failed
+const markStatus = async (influxdb, url, state, timestamp, retry) => {
+    try {
+        const measurement = [ {
+            measurement: "status",
+            tags: { url: url, state: state },
+            fields: { date: timestamp, retry: retry }           
+        }];
+
+        const result = await influxdb.writePoints(measurement);
+        console.log(`Successfully added the state ${state} for ${url}`);
+        return result;
+    } catch (err) {
+        console.log(`Failed to add the state for ${url}`);
+        return Promise.reject(`Failed to add data to status.`)
+    }
+}
+
+//steps = {START, WAITING, RETRY 1, RETRY 2, ..., FINISHED}
+const markStatusLogs = async (influxdb, step, timestamp) => {
+    try {
+        const measurement = [ {
+            measurement: "status-logs",
+            tags: {step: step },
+            fields: { date: timestamp }
+        }];
+
+        const result = await influxdb.writePoints(measurement);
+        console.log(`Successfully added step ${step}`);
+        return result;
+    } catch (err) {
+        console.log(`Failed to add step ${step}`);
+        return Promise.reject(`Failed to add step ${step}.`)
+    }
+}
+
 module.exports = {
     init,
     create_db,
     saveData,
-    markSuccess
+    markSuccess,
+    markStatus,
+    markStatusLogs
 }

--- a/src/utils/app.js
+++ b/src/utils/app.js
@@ -4,6 +4,9 @@ const serveIndex = require('serve-index');
 const extend = require('extend')
 const { reportDir } = require('./helpers');
 const plugin = require('../plugin');
+const nunjucks = require('nunjucks');
+const sleep = require('sleep-promise');
+
 
 const JOB_LIFETIME = 24 * 3600;
 
@@ -12,9 +15,138 @@ const createApp = (settings, influx_obj) => {
   app.use(bodyParser.json());
 
   app.use('/reports', express.static('reports'), serveIndex('reports', { icons: true }));
+  
+  const nunjucksEnv = nunjucks.configure(`${__dirname}/views`, {
+    autoescape: true,
+    express: app,
+    watch: true,
+  });
+  
+  nunjucksEnv.addGlobal('settings', settings)
 
-  if (settings.onDemand) {
+  async function getCurrentChecks(waitingStateTimestamp, startTimestamp) {
+    const runningChecks = await influx_obj.query(`select * from status where state=\'1\' or state=\'2\' and time<=${waitingStateTimestamp} and time>=${startTimestamp}`);
+    const failedChecks = await influx_obj.query(`select * from status where state=\'2\' and time<=${waitingStateTimestamp} and time>=${startTimestamp}`);
+
+    const duration = (waitingStateTimestamp - startTimestamp) / 1000000000;
+    
+    const currentChecks = {
+      runningChecks: runningChecks.length,
+      failedChecks: failedChecks.length,
+      startTime: startTimestamp,
+      duration: duration
+    }
+
+    return currentChecks;
+  }
+
+
+  async function getCurrentRetries(waitingStateTimestamp, statusLogsRows) {
+
+    const retries = [];
+    if (statusLogsRows.length === 0) {
+      return {retries};
+    }
+
+    const runningRetries = await influx_obj.query(`select * from status where state=\'1\' or state=\'2\' and time > ${waitingStateTimestamp}`);
+    
+    for (let i = 0; i < statusLogsRows.length - 1; i++) {
+      if (statusLogsRows[i].step.includes("RETRY")) {
+        retries.push({
+          duration: (statusLogsRows[i + 1].time.getNanoTime() - statusLogsRows[i].time.getNanoTime()) / 1000000000,
+          success: 0,
+          fail : 0
+        });
+      }
+    }
+      if (statusLogsRows[statusLogsRows.length - 1].step.includes("RETRY")) {
+        retries.push({
+          duration: (Date.now() * 1000000 - statusLogsRows[statusLogsRows.length - 1].time.getNanoTime()) / 1000000000,
+          success: 0,
+          fail : 0
+        })
+      }
+    
+    for (let row of runningRetries) {
+      if (row.state == 1) {
+        retries[row.retry - 1].success++;
+        
+      } else if(row.state == 2) {
+        retries[row.retry - 1].fail++;
+      }
+    }
+
+    const currentRetries = {
+      retries
+    };
+
+    return currentRetries;
+  }
+
+	app.get('/status', async (req, res) => {
+
+    const defaultMessage = "Plugin has not started yet."
+    const nrUrls = settings.config.urls.length;
+
+    let tablesToShow = {first: false, retries: false, finish: false};
+
+    const statusLogsQuery = await influx_obj.query('select last(*) from "status-logs" group by step order by time asc');
+    if (statusLogsQuery.length === 0) {
+      return res.render('status.html', { defaultMessage });
+    }
+    statusLogsQuery.sort((a, b) => {
+      return a.time > b.time;
+    });
+
+    let idx = statusLogsQuery.findIndex(elem => elem.step === "START");
+    const statusLogsRows= statusLogsQuery.slice(idx);
+    const startTimestamp = statusLogsRows[0].time.getNanoTime();
+    const startTime = statusLogsRows[0].time.toISOString();
+
+    let waitingTimestamp = Date.now() * 1000000;
+    if (statusLogsRows.length >= 1) {
+      waitingTimestamp = statusLogsRows[1].time.getNanoTime();
+    }
+
+    const currentlyRunningChecksTable = await getCurrentChecks(waitingTimestamp, startTimestamp);
+    const currentlyRunningRetriesTable = await getCurrentRetries(waitingTimestamp, statusLogsRows.slice(2));
+
+    if (statusLogsRows[statusLogsRows.length - 1].step === "START" ||
+        statusLogsRows[statusLogsRows.length - 1].step === "WAITING") {
+
+      tablesToShow.first = true;
+      return res.render('status.html', { nrUrls, currentlyRunningChecksTable, tablesToShow });
+    
+    } else if (statusLogsRows[statusLogsRows.length - 1].step.includes("RETRY")) {
+    
+      tablesToShow.first = true;
+      tablesToShow.retries = true;
+      return res.render('status.html', { nrUrls, currentlyRunningChecksTable, currentlyRunningRetriesTable, tablesToShow });
+
+    } else if (statusLogsRows[statusLogsRows.length - 1].step === "FINISHED") {
+     
+      const finishTime = statusLogsRows[statusLogsRows.length - 1].time.getNanoTime();
+      const totalRunningTime = (finishTime - startTimestamp) / 1000000000;
+      const successful = await influx_obj.query(`select * from success where time>=${startTimestamp}`);      
+      const countSuccess = successful.length;
+
+
+      tablesToShow.first = true;
+      tablesToShow.retries = true;
+      tablesToShow.finish = true;
+      return res.render('status.html', { nrUrls, currentlyRunningChecksTable, currentlyRunningRetriesTable,
+        startTime, totalRunningTime, countSuccess, tablesToShow });
+     
+    }
+
+    return res.render('status.html', { defaultMessage });
+  });
+  
+
+    if (settings.onDemand) {
     const scanQueue = {};
+    let data = {};
+    let measurement = [];
 
     const launchScanOnDemand = async (url, scan) => {
       try {
@@ -36,8 +168,8 @@ const createApp = (settings, influx_obj) => {
           getMeasurement,
         };
         console.log(`Launching scan on demand for ${url}`);
-        const data = await plugin.plugin_getData(item);
-        let measurement = [];
+        data = await plugin.plugin_getData(item);
+        measurement = [];
         if (data !== null) {
           measurement = await plugin.plugin_getMeasurement(item, data);
         }

--- a/src/utils/views/base.html
+++ b/src/utils/views/base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+{% block head %}
+<meta charset="utf8">
+
+<title>{% block title %}Plugin Status{% endblock %}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+
+</style>
+
+{% endblock %}
+
+<body>
+
+{% block navbar %}
+
+{% endblock %}
+
+{% block content %}
+{% endblock %}

--- a/src/utils/views/base.html
+++ b/src/utils/views/base.html
@@ -2,10 +2,13 @@
 {% block head %}
 <meta charset="utf8">
 
-<title>{% block title %}Plugin Status{% endblock %}</title>
+{% block title %}
+    <title>
+        Plugin Status
+    </title>
+{% endblock %}
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
-
 </style>
 
 {% endblock %}
@@ -18,3 +21,4 @@
 
 {% block content %}
 {% endblock %}
+</body>

--- a/src/utils/views/status.html
+++ b/src/utils/views/status.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+{% block head %}
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+{% endblock %}
+<script>
+
+</script>
+{% block content %}
+<body>
+    <br>
+    {{ defaultMessage }}
+    <br>
+    <div class="table-responsive">
+        <table
+            class="table table-striped table-sm"
+            id="data-table"
+            data-toggle="table">
+            <thead class="thead-dark">
+                <tr>
+                    <th scope="col" data-field="blank">
+
+                    </th>
+                    <th scope="col" data-field="urls-checked">
+                        URL's checked
+                    </th>
+                    <th scope="col" data-field="failed-checks">
+                        Failures
+                    </th>
+                    <th colspan="3" scope="colgroup">
+                        Time
+                    </th>
+                </tr>
+            </thead>
+            {% if tablesToShow.first %}
+            <tbody>
+                <tr>
+                    <th rowspan="3" scope = "rowgroup">
+                        Checks Currently Running
+                    </th>
+                    <td>
+                        {{ currentlyRunningChecksTable.runningChecks }} / {{ nrUrls }}
+                    </td>
+                    <td>
+                        {{ currentlyRunningChecksTable.failedChecks }} / {{ nrUrls }}
+                    </td>
+                    <td>
+                        Run for {{ currentlyRunningChecksTable.duration }} s
+                    </td>
+                </tr>
+            </tbody>
+            {% endif %}
+            {% if tablesToShow.retries %}
+            {% for row in currentlyRunningRetriesTable.retries %}
+            <tbody>
+                <tr>
+                    <th rowspan="4" scope = "rowgroup">
+                        Retries Currently Running - Retry nr. {{ loop.index }}
+                    </th>
+                    <td>
+                        {% if loop.index0 == 0 %}
+                            {{ row.success + row.fail }} / {{ currentlyRunningChecksTable.failedChecks }}
+                        {% else %}
+                            {{ row.success + row.fail }} / {{ currentlyRunningRetriesTable.retries[loop.index0 - 1].fail }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if loop.index0 == 0 %}
+                            {{ row.fail }} / {{ currentlyRunningChecksTable.failedChecks }}
+                        {% else %}
+                            {{ row.fail }} / {{ currentlyRunningRetriesTable.retries[loop.index0 - 1].fail }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        Run for: {{ row.duration }} s
+                    </td>
+                </tr>
+            </tbody>
+            {% endfor %}
+            {% endif %}
+        </table>
+    </div>
+    <br>
+    <br>
+    {% if tablesToShow.finish %}
+    <div class="table-responsive">
+        <table
+            class="table table-striped table-sm"
+            id="data-table"
+            data-toggle="table">
+            <thead class="thead-dark">
+                <tr>
+                    <th scope="col" data-field="blank">
+
+                    </th>
+                    <th scope="col" data-field="active-checks">
+                        Start Time
+                    </th>
+                    <th scope="col" data-field="failed-checks">
+                        Total Running Time
+                    </th>
+                    <th scope="col" data-field="failed-checks">
+                        Successful Checks / Total
+                    </th>
+                    <th colspan="4" scope="colgroup">
+                        Errors
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th rowspan="4" scope = "rowgroup">
+                        Last Performed
+                    </th>
+                    <td>
+                        {{ startTime }}
+                    </td>
+                    <td>
+                        {{ totalRunningTime }}
+                    </td>
+                    <td>
+                       {{ countSuccess }} / {{ nrUrls }}
+                    </td>
+                    <td>
+                        {{ nrUrls - countSuccess }} / {{ nrUrls }}
+                    </td>
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    
+</body>
+{% endblock %}
+

--- a/src/utils/views/status.html
+++ b/src/utils/views/status.html
@@ -8,13 +8,15 @@
 {% block content %}
 <body>
     <br>
-    {{ defaultMessage }}
+    <h1> {{ defaultMessage }} </h1>
     <br>
+    
     <div class="table-responsive">
         <table
-            class="table table-striped table-sm"
+            class="table table-striped"
             id="data-table"
-            data-toggle="table">
+            data-toggle="table"
+            style='font-family:"Courier New"; font-size:large'>
             <thead class="thead-dark">
                 <tr>
                     <th scope="col" data-field="blank">
@@ -50,32 +52,32 @@
             </tbody>
             {% endif %}
             {% if tablesToShow.retries %}
-            {% for row in currentlyRunningRetriesTable.retries %}
-            <tbody>
-                <tr>
-                    <th rowspan="4" scope = "rowgroup">
-                        Retries Currently Running - Retry nr. {{ loop.index }}
-                    </th>
-                    <td>
-                        {% if loop.index0 == 0 %}
-                            {{ row.success + row.fail }} / {{ currentlyRunningChecksTable.failedChecks }}
-                        {% else %}
-                            {{ row.success + row.fail }} / {{ currentlyRunningRetriesTable.retries[loop.index0 - 1].fail }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if loop.index0 == 0 %}
-                            {{ row.fail }} / {{ currentlyRunningChecksTable.failedChecks }}
-                        {% else %}
-                            {{ row.fail }} / {{ currentlyRunningRetriesTable.retries[loop.index0 - 1].fail }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        Run for: {{ row.duration }} s
-                    </td>
-                </tr>
-            </tbody>
-            {% endfor %}
+                {% for row in currentlyRunningRetriesTable.retries %}
+                    <tbody>
+                        <tr>
+                            <th rowspan="4" scope = "rowgroup">
+                                Retries Currently Running - Retry nr. {{ loop.index }}
+                            </th>
+                            <td>
+                                {% if loop.index0 == 0 %}
+                                    {{ row.success + row.fail }} / {{ currentlyRunningChecksTable.failedChecks }}
+                                {% else %}
+                                    {{ row.success + row.fail }} / {{ currentlyRunningRetriesTable.retries[loop.index0 - 1].fail }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if loop.index0 == 0 %}
+                                    {{ row.fail }} / {{ currentlyRunningChecksTable.failedChecks }}
+                                {% else %}
+                                    {{ row.fail }} / {{ currentlyRunningRetriesTable.retries[loop.index0 - 1].fail }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                Run for: {{ row.duration }} s
+                            </td>
+                        </tr>
+                    </tbody>
+                {% endfor %}
             {% endif %}
         </table>
     </div>
@@ -84,9 +86,10 @@
     {% if tablesToShow.finish %}
     <div class="table-responsive">
         <table
-            class="table table-striped table-sm"
+            class="table table-striped"
             id="data-table"
-            data-toggle="table">
+            data-toggle="table"
+            style='font-family:"Courier New"; font-size:large'>
             <thead class="thead-dark">
                 <tr>
                     <th scope="col" data-field="blank">


### PR DESCRIPTION
This commit includes the route /status for the plugins to have in order to be able to observe the status of the url checking while the plugin is running.

I created two more measurements in the plugin's database, namely status-logs and status. In status-logs I have entries for the step we're at while the plugin is running (e.g. START, WAITING, RETRY 1, etc) that help us in querying "status" for certain entries in a specific interval of time.

In status we have for each url a state (0 if it's still processing, 1 - ended successfully, 2-failed) with which we are able to identify how the plugin is doing, what went well, what failed.